### PR TITLE
feat: Update for Microsoft Agent Framework GA (v1.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
-# Creating AI Applications and Agents with C# - Semantic Kernel C# Workshop
+# Creating AI Applications and Agents with C# - Semantic Kernel & Microsoft Agent Framework Workshop
 
-A comprehensive workshop for building AI applications and agents using Microsoft's Semantic Kernel framework in C#.
+A comprehensive workshop for building AI applications and agents using Microsoft's Semantic Kernel framework and the newly GA **Microsoft Agent Framework** in C#.
+
+> **🆕 Updated for Microsoft Agent Framework GA (v1.0.0) and Microsoft.Extensions.AI GA**  
+> See the [Microsoft Agent Framework GA Migration Guide](docs/MICROSOFT_AGENT_FRAMEWORK_GA.md) for what changed and how to adapt your code.
 
 ## 📚 Workshop Overview
 
 This workshop teaches you how to create intelligent AI agents that can collaborate as a software development team. You'll learn to build an AI Coding Assistant capable of performing complex software development tasks through multi-agent orchestration.
 
+The workshop content is based on **Semantic Kernel** — which is now a core component of the unified **Microsoft Agent Framework** alongside AutoGen. Everything you learn here applies directly to the GA framework.
+
 ## 🎯 Learning Path
+
+### ⚠️ Notebook Environment Notice (Polyglot Notebooks Deprecation)
+
+The interactive notebooks (`.ipynb`) in this workshop use the **C# kernel** (previously known as Polyglot Notebooks / .NET Interactive). **Microsoft deprecated Polyglot Notebooks in February 2026** — no new features or bug fixes will be shipped for the VS Code extension.
+
+**Recommended alternatives for running C# notebooks:**
+- **[Verso](https://github.com/DataficationSDK/Verso)** — open-source drop-in replacement that imports `.ipynb` files and supports the .NET kernel (best option for this workshop)
+- **[.NET Script files](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-options/top-level-statements)** — run the C# snippets from each notebook as standalone `.csx` scripts
+- **Jupyter with the C# kernel** — if you already have Jupyter installed, install the `dotnet-interactive` Jupyter kernel while it still works
+
+> If you're running the workshop and notebooks don't execute, switch to Verso or the `.csx` scripts in `notebooks/scripts/` (coming soon).
 
 ### 📓 Interactive Notebooks
 Hands-on learning materials covering core concepts:
@@ -48,10 +64,51 @@ Progressive exercises to build your skills:
 
 👉 **[See complete setup instructions](docs/README.md#-quick-start)**
 
+## 🤖 Microsoft Agent Framework GA
+
+Microsoft Agent Framework v1.0.0 (GA, April 2026) is the **unified AI agent platform** for .NET that merges:
+- **Semantic Kernel** — enterprise agents, plugins, memory, telemetry
+- **AutoGen** — multi-agent orchestration from Microsoft Research
+
+Key GA capabilities relevant to this workshop:
+
+| Feature | Package | Status |
+|---------|---------|--------|
+| `IChatClient` / `IEmbeddingGenerator` abstractions | `Microsoft.Extensions.AI` | ✅ **GA** |
+| Semantic Kernel agents & plugins | `Microsoft.SemanticKernel` (v1.74+) | ✅ **GA** |
+| Process Framework (stateful workflows) | `Microsoft.SemanticKernel.Process.Core` | ✅ **GA** |
+| A2A Protocol support | Built into SK Agents | ✅ **GA** |
+| MCP tool integration | `Microsoft.SemanticKernel.Mcp` | ✅ **GA** |
+| Graph-based multi-agent orchestration | `Microsoft.Extensions.AI` pipeline | ✅ **GA** |
+
+**Key links:**
+- 📖 [Microsoft Agent Framework blog](https://devblogs.microsoft.com/agent-framework/)
+- 🐙 [GitHub: microsoft/agent-framework](https://github.com/microsoft/agent-framework)
+- 📦 [NuGet: Microsoft.SemanticKernel](https://www.nuget.org/packages/Microsoft.SemanticKernel/) (v1.74+)
+- 📦 [NuGet: Microsoft.Extensions.AI](https://www.nuget.org/packages/Microsoft.Extensions.AI/)
+- 🔄 [Migration guide from preview → GA](docs/MICROSOFT_AGENT_FRAMEWORK_GA.md)
+
+## 📦 Current Package Versions
+
+This workshop targets the following GA package versions (as of mid-2026):
+
+```xml
+<PackageReference Include="Microsoft.SemanticKernel" Version="1.74.0" />
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.7.1" />
+<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.10.0" />
+<PackageReference Include="Azure.AI.OpenAI" Version="2.5.0" />
+```
+
+> **Note:** Some notebooks may reference older preview versions (e.g., `Microsoft.Extensions.AI.OpenAI 9.7.1-preview.*`). Update to GA versions when running locally. See the [migration guide](docs/MICROSOFT_AGENT_FRAMEWORK_GA.md) for details.
+
+
+
 ## 📖 Additional Resources
 
+- **[Microsoft Agent Framework GA Guide](docs/MICROSOFT_AGENT_FRAMEWORK_GA.md)** - What changed from preview to GA and how to migrate
 - **[GitHub Models Setup Guide](docs/Using_GitHub_Models.md)** - Configure GitHub marketplace models
 - **[Notebook Learning Materials](notebooks/)** - Interactive Jupyter notebooks
 - **[Assignment Solutions](docs/assignments/)** - Guided exercises
-
+- **[Microsoft Agent Framework blog](https://devblogs.microsoft.com/agent-framework/)** - Official announcements and deep-dives
+- **[dotnet/extensions on GitHub](https://github.com/dotnet/extensions)** - Source for `Microsoft.Extensions.AI`
 

--- a/docs/MICROSOFT_AGENT_FRAMEWORK_GA.md
+++ b/docs/MICROSOFT_AGENT_FRAMEWORK_GA.md
@@ -1,0 +1,178 @@
+# Microsoft Agent Framework GA — What Changed & How to Migrate
+
+> **Last updated:** June 2026  
+> **Framework version:** Microsoft Agent Framework v1.0.0 (GA)  
+> **Semantic Kernel version:** v1.74+  
+> **Microsoft.Extensions.AI version:** 9.7.1 (Abstractions: 9.10.0)
+
+---
+
+## What is Microsoft Agent Framework?
+
+**Microsoft Agent Framework** (MAF) is Microsoft's unified, production-ready platform for building AI agents with .NET. It merges two previously separate frameworks:
+
+| Before (Preview) | After (GA — Agent Framework) |
+|---|---|
+| Semantic Kernel (enterprise agents, plugins) | Core component of Agent Framework |
+| AutoGen (multi-agent from MSR) | Core component of Agent Framework |
+| Separate teams, docs, packages | Single unified platform |
+
+The GA release is available at:
+- **GitHub:** https://github.com/microsoft/agent-framework
+- **Blog:** https://devblogs.microsoft.com/agent-framework/
+- **NuGet:** [microsoft/agent-framework packages](https://www.nuget.org/profiles/MicrosoftAgentFramework/)
+
+---
+
+## What Changed from Preview to GA
+
+### Microsoft.Extensions.AI
+
+| Area | Preview | GA |
+|---|---|---|
+| `IChatClient` interface | Experimental, evolving | ✅ Stable, versioned |
+| `IEmbeddingGenerator<TInput,TEmbedding>` | Experimental | ✅ Stable |
+| Platform targets | .NET 6, 7, 8 | .NET 8, .NET 9, .NET 4.6.2, netstandard2.0 |
+| Provider integrations | Reference only | Open to all ISVs; plug-and-play |
+| OpenTelemetry middleware | Preview | ✅ Stable via `UseOpenTelemetry()` |
+| Caching / rate-limiting middleware | Preview | ✅ Stable pipeline |
+| `Microsoft.Extensions.VectorData` | Preview | ✅ GA alongside MEAI |
+
+**NuGet package update:**
+```xml
+<!-- Before (preview) -->
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.0.0-preview.*" />
+
+<!-- After (GA) -->
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.7.1" />
+<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.10.0" />
+```
+
+### Semantic Kernel (as part of Agent Framework)
+
+| Area | Preview / v1.x early | GA (v1.74+) |
+|---|---|---|
+| `KernelFunction` / plugins | Stable | ✅ No change needed |
+| `ChatCompletionAgent` | Experimental | ✅ GA |
+| Process Framework (`KernelProcess`) | Preview | ✅ GA |
+| A2A Protocol | Preview | ✅ GA |
+| MCP tool integration | Preview | ✅ GA |
+| Multi-agent `AgentGroupChat` | Experimental | ✅ GA (use `AgentChat` APIs) |
+| `ITextEmbeddingGenerationService` | Stable SK interface | ⚠️ Transitioning to `IEmbeddingGenerator` from MEAI |
+
+**Package update:**
+```xml
+<!-- Minimum recommended version -->
+<PackageReference Include="Microsoft.SemanticKernel" Version="1.74.0" />
+```
+
+### Microsoft Agent Framework (new unified packages)
+
+For new projects targeting the full Agent Framework:
+```xml
+<PackageReference Include="Microsoft.Extensions.AI" Version="9.7.1" />
+<PackageReference Include="Microsoft.SemanticKernel" Version="1.74.0" />
+<PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.74.0" />
+<PackageReference Include="Microsoft.SemanticKernel.Process.Core" Version="1.74.0" />
+```
+
+---
+
+## New GA Features in This Workshop
+
+### 1. Graph-Based Agent Orchestration
+The GA release introduces stateful, graph-based workflows — think LangGraph for .NET.
+
+```csharp
+// GA: Use KernelProcess for stateful, event-driven workflows
+var processBuilder = new ProcessBuilder("CodeReviewWorkflow");
+var analyzeStep = processBuilder.AddStepFromType<AnalyzeCodeStep>();
+var reviewStep = processBuilder.AddStepFromType<ReviewCodeStep>();
+
+processBuilder
+    .OnInputEvent("StartReview")
+    .SendEventTo(new ProcessFunctionTargetBuilder(analyzeStep));
+    
+analyzeStep
+    .OnFunctionResult()
+    .SendEventTo(new ProcessFunctionTargetBuilder(reviewStep));
+```
+
+### 2. A2A Protocol (Agent-to-Agent)
+Standard protocol for agent-to-agent communication across different frameworks and runtimes:
+
+```csharp
+// See notebooks/6-Agent-to-Agent-Protocol.ipynb
+// GA: A2A is now a first-class citizen in Semantic Kernel Agents
+```
+
+### 3. MCP Integration (GA)
+Model Context Protocol for connecting agents to external tools:
+
+```csharp
+// See notebooks/3.2-MCP.ipynb
+// GA: Microsoft.SemanticKernel.Mcp is stable
+```
+
+---
+
+## Notebook Environment: Polyglot Notebooks Deprecation
+
+> ⚠️ **Important for workshop attendees**
+
+Microsoft deprecated **Polyglot Notebooks** (the VS Code extension that powered `.ipynb` C# execution) in **February 2026**. No new features or bug fixes will be released.
+
+### What this means for the workshop notebooks
+
+The `.ipynb` files in `notebooks/` use the C#/Polyglot kernel (`"kernelName": "csharp"`). They **will continue to work** as long as the deprecated extension is installed, but:
+- You cannot install it fresh from the marketplace for much longer
+- Bug fixes will not come for kernel issues
+
+### Recommended alternatives (in order of preference)
+
+| Option | Best for | Notes |
+|---|---|---|
+| **[Verso](https://github.com/DataficationSDK/Verso)** | Drop-in replacement for Polyglot | Imports `.ipynb`, .NET engine, open-source |
+| **.csx script files** | Running individual notebook cells | Use `dotnet-script` or `csi` |
+| **Regular C# console project** | Full code samples | Best for production-pattern learning |
+| **Jupyter + dotnet-interactive kernel** | Familiar Jupyter UX | Works while `dotnet-interactive` still has kernel support |
+
+### Running a notebook cell as a .csx script
+
+Any cell that starts with `#r "nuget: ..."` can be run as a C# script:
+
+```bash
+# Install dotnet-script (one time)
+dotnet tool install -g dotnet-script
+
+# Run a notebook cell as a script
+dotnet script notebooks/scripts/1-intro-example.csx
+```
+
+---
+
+## Migration Steps for Existing Code
+
+If you have code written against preview packages, here's a quick checklist:
+
+- [ ] Update `Microsoft.Extensions.AI` to `9.7.1`
+- [ ] Update `Microsoft.Extensions.AI.Abstractions` to `9.10.0`
+- [ ] Update `Microsoft.SemanticKernel` to `1.74.0`
+- [ ] Replace `Microsoft.Extensions.AI.OpenAI` preview references with the stable version
+- [ ] If using `ITextEmbeddingGenerationService`, plan migration to `IEmbeddingGenerator<string, Embedding<float>>` (SK provides adapters)
+- [ ] If using `AgentGroupChat`, check the updated API surface — some overloads changed
+- [ ] Update `Azure.AI.OpenAI` from `2.5.0-beta.*` to `2.5.0` (stable)
+
+---
+
+## Resources
+
+- 📖 [Agent Framework blog](https://devblogs.microsoft.com/agent-framework/)
+- 🐙 [microsoft/agent-framework on GitHub](https://github.com/microsoft/agent-framework)
+- 🐙 [dotnet/extensions on GitHub](https://github.com/dotnet/extensions) (source for `Microsoft.Extensions.AI`)
+- 📦 [Microsoft.Extensions.AI on NuGet](https://www.nuget.org/packages/Microsoft.Extensions.AI/)
+- 📦 [Microsoft.SemanticKernel on NuGet](https://www.nuget.org/packages/Microsoft.SemanticKernel/)
+- 📄 [MEAI official docs](https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai)
+- 🔗 [Polyglot Notebooks deprecation info](https://www.devclass.com/databases/2026/02/14/microsoft-deprecates-polyglot-notebooks-developers-react/)
+- 🔗 [Verso — open-source Polyglot replacement](https://github.com/DataficationSDK/Verso)
+- 📄 [Transitioning to new IEmbeddingGenerator interface](https://devblogs.microsoft.com/agent-framework/transitioning-to-new-iembeddinggenerator-interface/)

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,6 +1,14 @@
 # Semantic Kernel Workshop Notebooks
 
-This directory contains interactive Jupyter notebooks that guide you through learning Semantic Kernel concepts and building AI agents with C#.
+> ⚠️ **Polyglot Notebooks Deprecation Notice (February 2026)**
+>
+> Microsoft deprecated the Polyglot Notebooks VS Code extension in February 2026. The `.ipynb` C# notebooks in this directory **use the Polyglot/C# kernel** and may not work in fresh VS Code setups.
+>
+> **Recommended:** Use **[Verso](https://github.com/DataficationSDK/Verso)** as a drop-in replacement — it imports `.ipynb` files and supports the .NET kernel. Alternatively, run code samples as `.csx` scripts with `dotnet-script`.
+>
+> See the [Microsoft Agent Framework GA guide](../docs/MICROSOFT_AGENT_FRAMEWORK_GA.md#notebook-environment-polyglot-notebooks-deprecation) for full details and alternatives.
+
+This directory contains interactive notebooks that guide you through building AI agents with **Semantic Kernel** and **Microsoft Agent Framework** in C#.
 
 ## 📚 Learning Sequence
 
@@ -27,8 +35,24 @@ Work through these notebooks in order to build your understanding progressively:
 
 ### Prerequisites
 - .NET 9 SDK or later
-- Jupyter notebook environment with .NET Interactive kernel
+- **Notebook runner** — one of:
+  - [Verso](https://github.com/DataficationSDK/Verso) (recommended — open-source Polyglot replacement)
+  - Polyglot Notebooks VS Code extension (deprecated but still installable for now)
+  - `dotnet-script` for running cells as `.csx` scripts
 - AI model access (Azure OpenAI, GitHub Models, or local LLM)
+
+### Package Versions (GA)
+
+The notebooks reference these GA package versions:
+
+```
+Microsoft.SemanticKernel             1.74.0
+Microsoft.Extensions.AI             9.7.1
+Microsoft.Extensions.AI.Abstractions 9.10.0
+Azure.AI.OpenAI                      2.5.0
+```
+
+> Some notebooks may still reference older preview versions in their `#r nuget:` directives. Update them to the GA versions above for best results.
 
 ### Configuration
 1. **AI Settings**: Start with [`0-AI-settings.ipynb`](0-AI-settings.ipynb) to configure your model


### PR DESCRIPTION
## Summary

Updates the workshop to reflect the **Microsoft Agent Framework v1.0.0 GA release** (April 2026) and addresses the **Polyglot Notebooks deprecation** (February 2026).

## Changes

### \README.md\
- Updated title to mention both Semantic Kernel and Microsoft Agent Framework
- Added GA banner linking to the migration guide
- Added Polyglot Notebooks deprecation warning with recommended alternatives (Verso, .csx, Jupyter)
- Added Microsoft Agent Framework GA section with feature table and links
- Added Package Versions section with current GA NuGet versions

### \docs/MICROSOFT_AGENT_FRAMEWORK_GA.md\ (new)
Migration guide covering what changed from preview to GA, notebook deprecation, and package migration checklist.

### \
otebooks/README.md\
- Added deprecation notice with GA package version table

## Key facts
- Microsoft Agent Framework v1.0.0 GA: https://github.com/microsoft/agent-framework/releases
- Semantic Kernel latest stable: v1.74.0
- Microsoft.Extensions.AI GA: 9.7.1
- Polyglot Notebooks deprecated: Feb 2026, recommend Verso as replacement

Closes tamirdresher_microsoft/tamresearch1#2117